### PR TITLE
proposal for distinguishing between library- and user-code say()

### DIFF
--- a/packages/kernel/src/Actor.js
+++ b/packages/kernel/src/Actor.js
@@ -86,7 +86,7 @@ export class Actor extends WorldcoreModel {
             this[ul] = value;
             if (this[nameSet]) this[nameSet](value,old);
             const data = {old, value, o: old, v: value};
-            this.say(nameSet, data);
+            this.sayProp(nameSet, data);
         }
         return sorted;
     }
@@ -98,7 +98,7 @@ export class Actor extends WorldcoreModel {
             const value = option[1];
             const nameSnap = name+'Snap';
             if (this[nameSnap]) this[nameSnap](value);
-            this.say(nameSnap, value);
+            this.sayProp(nameSnap, value);
         }
     }
 
@@ -121,6 +121,15 @@ export class Actor extends WorldcoreModel {
     }
 
     say(event, data) {
+        // an explicit say(), as opposed to the automatically generated sayProp().
+        // we publish in the normal way, but also as arguments to a generic event
+        // type that a client such as a bridge can subscribe to in order to capture
+        // and forward all the explicit say() occurrences.
+        this.publish(this.id, event, data);
+        this.publish("__wc", "say", [ this.id, event, data ]);
+    }
+
+    sayProp(event, data) {
         this.publish(this.id, event, data);
     }
 

--- a/packages/kernel/src/Actor.js
+++ b/packages/kernel/src/Actor.js
@@ -86,7 +86,7 @@ export class Actor extends WorldcoreModel {
             this[ul] = value;
             if (this[nameSet]) this[nameSet](value,old);
             const data = {old, value, o: old, v: value};
-            this.sayProp(nameSet, data);
+            this._say(nameSet, data);
         }
         return sorted;
     }
@@ -98,7 +98,7 @@ export class Actor extends WorldcoreModel {
             const value = option[1];
             const nameSnap = name+'Snap';
             if (this[nameSnap]) this[nameSnap](value);
-            this.sayProp(nameSnap, value);
+            this._say(nameSnap, value);
         }
     }
 
@@ -121,7 +121,7 @@ export class Actor extends WorldcoreModel {
     }
 
     say(event, data) {
-        // an explicit say(), as opposed to the automatically generated sayProp().
+        // an explicit say(), as opposed to the automatically generated _say().
         // we publish in the normal way, but also as arguments to a generic event
         // type that a client such as a bridge can subscribe to in order to capture
         // and forward all the explicit say() occurrences.
@@ -129,7 +129,7 @@ export class Actor extends WorldcoreModel {
         this.publish("__wc", "say", [ this.id, event, data ]);
     }
 
-    sayProp(event, data) {
+    _say(event, data) {
         this.publish(this.id, event, data);
     }
 

--- a/packages/kernel/src/Mixins.js
+++ b/packages/kernel/src/Mixins.js
@@ -164,7 +164,7 @@ export const AM_Spatial = superclass => class extends superclass {
 
     globalChanged() {
         this.$global = null;
-        this.sayProp("globalChanged");
+        this._say("globalChanged");
         if (this.children) this.children.forEach(child => child.globalChanged());
     }
 
@@ -295,7 +295,7 @@ export const PM_Smoothed = superclass => class extends PM_Spatial(superclass) {
     scaleTo(v) {
         this._scale = v;
         this.localChanged();
-        this.sayProp("setScale", v, this.throttle);
+        this.say("setScale", v, this.throttle);
         this.refreshDrawTransform();
         this.refreshChildDrawTransform();
     }
@@ -303,7 +303,7 @@ export const PM_Smoothed = superclass => class extends PM_Spatial(superclass) {
     rotateTo(q) {
         this._rotation = q;
         this.localChanged();
-        this.sayProp("setRotation", q, this.throttle);
+        this.say("setRotation", q, this.throttle);
         this.refreshDrawTransform();
         this.refreshChildDrawTransform();
     }
@@ -311,7 +311,7 @@ export const PM_Smoothed = superclass => class extends PM_Spatial(superclass) {
     translateTo(v) {
         this._translation = v;
         this.localChanged();
-        this.sayProp("setTranslation", v, this.throttle);
+        this.say("setTranslation", v, this.throttle);
         this.refreshDrawTransform();
         this.refreshChildDrawTransform();
     }
@@ -320,7 +320,7 @@ export const PM_Smoothed = superclass => class extends PM_Spatial(superclass) {
         this._translation = v;
         this._rotation = q;
         this.localChanged();
-        this.sayProp("setPosition", [v,q], this.throttle);
+        this.say("setPosition", [v,q], this.throttle);
         this.refreshDrawTransform();
         this.refreshChildDrawTransform();
     }

--- a/packages/kernel/src/Mixins.js
+++ b/packages/kernel/src/Mixins.js
@@ -164,7 +164,7 @@ export const AM_Spatial = superclass => class extends superclass {
 
     globalChanged() {
         this.$global = null;
-        this.say("globalChanged");
+        this.sayProp("globalChanged");
         if (this.children) this.children.forEach(child => child.globalChanged());
     }
 
@@ -295,7 +295,7 @@ export const PM_Smoothed = superclass => class extends PM_Spatial(superclass) {
     scaleTo(v) {
         this._scale = v;
         this.localChanged();
-        this.say("setScale", v, this.throttle);
+        this.sayProp("setScale", v, this.throttle);
         this.refreshDrawTransform();
         this.refreshChildDrawTransform();
     }
@@ -303,7 +303,7 @@ export const PM_Smoothed = superclass => class extends PM_Spatial(superclass) {
     rotateTo(q) {
         this._rotation = q;
         this.localChanged();
-        this.say("setRotation", q, this.throttle);
+        this.sayProp("setRotation", q, this.throttle);
         this.refreshDrawTransform();
         this.refreshChildDrawTransform();
     }
@@ -311,7 +311,7 @@ export const PM_Smoothed = superclass => class extends PM_Spatial(superclass) {
     translateTo(v) {
         this._translation = v;
         this.localChanged();
-        this.say("setTranslation", v, this.throttle);
+        this.sayProp("setTranslation", v, this.throttle);
         this.refreshDrawTransform();
         this.refreshChildDrawTransform();
     }
@@ -320,7 +320,7 @@ export const PM_Smoothed = superclass => class extends PM_Spatial(superclass) {
         this._translation = v;
         this._rotation = q;
         this.localChanged();
-        this.say("setPosition", [v,q], this.throttle);
+        this.sayProp("setPosition", [v,q], this.throttle);
         this.refreshDrawTransform();
         this.refreshChildDrawTransform();
     }

--- a/packages/kernel/src/NavGrid.js
+++ b/packages/kernel/src/NavGrid.js
@@ -260,7 +260,7 @@ export const AM_NavGrid = superclass => class extends AM_Grid(superclass) {
             }
         }
 
-        this.sayProp("navGridChanged");
+        this._say("navGridChanged");
     }
 
     addBlock(x,y) {

--- a/packages/kernel/src/NavGrid.js
+++ b/packages/kernel/src/NavGrid.js
@@ -260,7 +260,7 @@ export const AM_NavGrid = superclass => class extends AM_Grid(superclass) {
             }
         }
 
-        this.say("navGridChanged");
+        this.sayProp("navGridChanged");
     }
 
     addBlock(x,y) {

--- a/packages/kernel/src/Pawn.js
+++ b/packages/kernel/src/Pawn.js
@@ -169,11 +169,11 @@ export class Pawn extends WorldcoreView {
     }
 
     set(options, throttle = 0) {
-        this.sayProp("_set", options, throttle);
+        this.say("_set", options, throttle);
     }
 
     snap(options, throttle = 0) {
-        this.sayProp("_snap", options, throttle);
+        this.say("_snap", options, throttle);
     }
 
     preUpdate(time, delta) {} // Called immediately before the main update

--- a/packages/kernel/src/Pawn.js
+++ b/packages/kernel/src/Pawn.js
@@ -169,11 +169,11 @@ export class Pawn extends WorldcoreView {
     }
 
     set(options, throttle = 0) {
-        this.say("_set", options, throttle);
+        this.sayProp("_set", options, throttle);
     }
 
     snap(options, throttle = 0) {
-        this.say("_snap", options, throttle);
+        this.sayProp("_snap", options, throttle);
     }
 
     preUpdate(time, delta) {} // Called immediately before the main update

--- a/packages/rapier/src/RapierPhysics.js
+++ b/packages/rapier/src/RapierPhysics.js
@@ -79,7 +79,7 @@ export class RapierPhysicsManager extends ModelService {
                 const q = [r.x, r.y, r.z, r.w];
 
                 rb.moveTo(v);
-                rb.sayProp("translating", v);
+                rb._say("translating", v);
                 rb.rotateTo(q);
             });
             if (this.queue) {

--- a/packages/rapier/src/RapierPhysics.js
+++ b/packages/rapier/src/RapierPhysics.js
@@ -79,7 +79,7 @@ export class RapierPhysicsManager extends ModelService {
                 const q = [r.x, r.y, r.z, r.w];
 
                 rb.moveTo(v);
-                rb.say("translating", v);
+                rb.sayProp("translating", v);
                 rb.rotateTo(q);
             });
             if (this.queue) {


### PR DESCRIPTION
In the Unity bridge, we would like to support listen() on Unity gameObjects in a way that feels similar to Worldcore pawns.

One challenge is in knowing in time which events to pass over the bridge; a listen() that's invoked only on Unity-pawn initialisation might be too late to capture events that have already been published.

David's proposed solution is to forward all explicit say() invocations _in user code_ on any actor, so even newly created pawns won't have missed anything.  We therefore wanted a way to suppress all the _automatic_ say() invocations from things like `actor.set()`.

In this commit, all internal say() calls are changed to sayProp()... but that could be anything.  say(), but not sayProp(), publishes an additional generic event that captures all the say parameters.